### PR TITLE
add ability to use gant cache from the gant ant task

### DIFF
--- a/src/main/groovy/gant/Gant.groovy
+++ b/src/main/groovy/gant/Gant.groovy
@@ -211,6 +211,26 @@ final class Gant {
     binding.removeBuildListener(buildListener)
   }
   /**
+   *  Set whether scripts are cached or not
+   */
+  public void setUseCache(final boolean useCache) {
+    this.useCache = useCache
+  }
+  /**
+   *  Set the location where the compiled scripts are cached.
+   */
+  public void setCacheDirectory(final File cacheDirectory) {
+    this.cacheDirectory = cacheDirectory
+  }
+  /**
+   *  Get the location where the compiled scripts are cached.
+   *
+   *  @return The <code>File</code> instance.
+   */
+  public File getCacheDirectory() {
+    return cacheDirectory
+  }
+  /**
    *  Treat the given text as a Gant script and load it.
    *
    *  @params text The text of the Gant script to load.

--- a/src/main/groovy/org/codehaus/gant/ant/Gant.java
+++ b/src/main/groovy/org/codehaus/gant/ant/Gant.java
@@ -69,6 +69,14 @@ public class Gant extends Task {
    */
   private boolean inheritAll = false;
   /**
+   *  Flag determining whether to cache the generated classes.
+   */
+  private boolean useCache = false;
+  /**
+   *  The directory where to cache generated classes to.
+   */
+  private File cacheDir = null;
+  /**
    *  A class representing a nested definition tag.
    */
   public static final class Definition {
@@ -139,6 +147,19 @@ public class Gant extends Task {
    */
   public void setInheritAll(final boolean value) { inheritAll = value; }
   /**
+   *  If true, cache the generated classes and perform modified checks on the
+   *  file before re-compilation.
+   *
+   *  @param value if true cache the generated classes.
+   */
+  public void setUseCache(final boolean value) { useCache = value; }
+  /**
+   *  The directory where to cache generated classes to.
+   *
+   *  @param value the cache directory.
+   */
+  public void setCacheDir(final File value) { cacheDir = value; }
+  /**
    * Load the file and then execute it.
    */
   @Override public void execute() throws BuildException {
@@ -186,6 +207,12 @@ public class Gant extends Task {
       ant.invokeMethod("property", new Object[] { definitionParameter });
     }
     final gant.Gant gant = new gant.Gant(binding);
+    gant.setUseCache(useCache);
+    if (useCache){
+      if (cacheDir != null) { gant.setCacheDirectory(cacheDir); }
+      // add the user defined or default cache diretory to ant's classloader.
+      ((AntClassLoader)getClass().getClassLoader()).addPathComponent(gant.getCacheDirectory());
+    }
     gant.loadScript(gantFile);
     final List<String> targetsAsStrings = new ArrayList<String>();
     for (final GantTarget g : targets) { targetsAsStrings.add(g.getValue()); }


### PR DESCRIPTION
I was looking to speed up the load time when running gant tasks from ant and found that gant already supported caching the compiled `.gant` file results, but that ability was not exposed to the `<gant>` task. This change adds that support by adding two new attributes to the `<gant>` task: useCache and cacheDir

Here is an example from my project utilizing these new attributes:

```
<gant
    file="ant/build.gant"
    target="${target}"
    inheritAll="true"
    useCache="true"
    cacheDir="build/temp/gant"
  />
```
