### PR TITLE
Fix JAVA_OPTS quotes in windows gant.bat start script

### DIFF
--- a/scripts/bin_requiresGroovy/gant.bat
+++ b/scripts/bin_requiresGroovy/gant.bat
@@ -55,7 +55,7 @@ if not "%ANT_HOME%" == "" goto endSetAntHome
 set PROGNAME=gant.bat
 set GROOVY_SCRIPT_NAME=gant.bat
 set STARTER_CONF="%GANT_HOME%\conf\gant-starter.conf"
-set JAVA_OPTS="%JAVA_OPTS%" -Dgant.home="%GANT_HOME%" -Dant.home="%ANT_HOME%"
+set JAVA_OPTS=%JAVA_OPTS% -Dgant.home="%GANT_HOME%" -Dant.home="%ANT_HOME%"
 
 "%GANT_HOME%\bin\startGroovy.bat" "%DIRNAME%" gant.Gant %*
 


### PR DESCRIPTION
Should fix https://jira.codehaus.org/browse/GANT-129
Tried on one of our server with next JAVA_OPTS combinations (note spaces):
set JAVA_OPTS=-Xms900m -Xmx1400m
set JAVA_OPTS=-Xmx1400m
set JAVA_OPTS=
